### PR TITLE
Add Beef version 5 schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -411,6 +411,32 @@
       ]
     },
     {
+      "name": "beef-database-v5-codegen",
+      "description": "Beef (Business Entity Execution Framework) database code-generation configuration (v5).",
+      "url": "https://raw.githubusercontent.com/Avanade/Beef/master/tools/Beef.CodeGen.Core/Schema/database.beef-5.json",
+      "fileMatch": [
+        "database.beef-5.yaml",
+        "database.beef-5.yml",
+        "database.beef-5.json"
+      ]
+    },
+    {
+      "name": "beef-entity-v5-codegen",
+      "description": "Beef (Business Entity Execution Framework) entity code-generation configuration (v5).",
+      "url": "https://raw.githubusercontent.com/Avanade/Beef/master/tools/Beef.CodeGen.Core/Schema/entity.beef-5.json",
+      "fileMatch": [
+        "entity.beef-5.yaml",
+        "entity.beef-5.yml",
+        "entity.beef-5.json",
+        "refdata.beef-5.yaml",
+        "refdata.beef-5.yml",
+        "refdata.beef-5.json",
+        "datamodel.beef-5.yaml",
+        "datamodel.beef-5.yml",
+        "datamodel.beef-5.json"
+      ]
+    },
+    {
       "name": "bigquery-table",
       "description": "BigQuery table schema",
       "url": "https://json.schemastore.org/bigquery-table.json",


### PR DESCRIPTION
Add new schemas to support upcoming [Beef](https://github.com/Avanade/Beef) version 5.